### PR TITLE
fix broken length fields in manifest

### DIFF
--- a/leveldb/pom.xml
+++ b/leveldb/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>leveldb</artifactId>
     <name>${project.artifactId}</name>
+    <version>0.11.1-SNAPSHOT</version>
     <description>Port of LevelDB to Java</description>
 
     <properties>
@@ -22,6 +23,7 @@
         <dependency>
             <groupId>org.iq80.leveldb</groupId>
             <artifactId>leveldb-api</artifactId>
+            <version>0.11-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/Compaction.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/Compaction.java
@@ -38,7 +38,7 @@ public class Compaction {
     private final List<FileMetaData>[] inputs;
 
     private final long maxOutputFileSize;
-    private final VersionEdit edit = new VersionEdit();
+    private final VersionEdit edit;
 
     // State used to check for number of of overlapping grandparent files
     // (parent == level_ + 1, grandparent == level_ + 2)
@@ -64,6 +64,7 @@ public class Compaction {
         this.grandparents = grandparents;
         this.maxOutputFileSize = VersionSet.maxFileSizeForLevel(level);
         this.inputs = new List[]{levelInputs, levelUpInputs};
+        this.edit = new VersionEdit(this.inputVersion.getVersionSet().getDatabaseDir());
     }
 
     public static long totalFileSize(List<FileMetaData> files) {

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/DbImpl.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/DbImpl.java
@@ -174,7 +174,7 @@ public class DbImpl
             }
 
             // Recover in the order in which the logs were generated
-            VersionEdit edit = new VersionEdit();
+            VersionEdit edit = new VersionEdit(this.databaseDir);
             Collections.sort(logs);
             for (Long fileNumber : logs) {
                 long maxSequence = recoverLogFile(fileNumber, edit);
@@ -829,7 +829,7 @@ public class DbImpl
 
         try {
             // Save the contents of the memtable as a new Table
-            VersionEdit edit = new VersionEdit();
+            VersionEdit edit = new VersionEdit(this.databaseDir);
             Version base = versions.getCurrent();
             writeLevel0Table(immutableMemTable, edit, base);
 

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/Version.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/Version.java
@@ -296,4 +296,8 @@ public class Version
     public boolean isDisposed() {
         return retained.get() <= 0;
     }
+
+    public VersionSet getVersionSet() {
+        return this.versionSet;
+    }
 }

--- a/leveldb/src/main/java/org/iq80/leveldb/impl/VersionSet.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/VersionSet.java
@@ -100,7 +100,7 @@ public class VersionSet
         File currentFile = new File(databaseDir, Filename.currentFileName());
 
         if (!currentFile.exists()) {
-            VersionEdit edit = new VersionEdit();
+            VersionEdit edit = new VersionEdit(this.databaseDir);
             edit.setComparatorName(internalKeyComparator.name());
             edit.setLogNumber(prevLogNumber);
             edit.setNextFileNumber(nextFileNumber.get());
@@ -294,7 +294,7 @@ public class VersionSet
     private void writeSnapshot(LogWriter log)
             throws IOException {
         // Save metadata
-        VersionEdit edit = new VersionEdit();
+        VersionEdit edit = new VersionEdit(this.databaseDir);
         edit.setComparatorName(internalKeyComparator.name());
 
         // Save compaction pointers
@@ -332,7 +332,7 @@ public class VersionSet
             LogReader reader = new LogReader(fileChannel, throwExceptionMonitor(), true, 0);
             for (Slice record = reader.readRecord(); record != null; record = reader.readRecord()) {
                 // read version edit
-                VersionEdit edit = new VersionEdit(record);
+                VersionEdit edit = new VersionEdit(record, this.databaseDir);
 
                 // verify comparator
                 // todo implement user comparator
@@ -613,6 +613,10 @@ public class VersionSet
             }
         }
         return result;
+    }
+
+    public File getDatabaseDir() {
+        return this.databaseDir;
     }
 
     /**


### PR DESCRIPTION
This is a hack to force the `fileSize` value of `FileMetaData` to always be the actual file size rather than the value read from the manifest. For some unknown reason the `fileSize` value written to the manifest is sometimes 4 bytes larger than the table file's actual size. Interestingly, the Java implementation doesn't make use of `fileSize` at all and instead uses the value from `FileChannel#size`, however the official C++ implementation uses it exclusively (causing databases created using the Java leveldb implementation to be completely unusable by the C++ implementation). As the metadata is rewritten every time the database is opened/closed, all that is needed to be done is open the database briefly with the Java implementation to fix the length fields in the manifest.