### PR TITLE
avoid breaking on older revisions in manifest

### DIFF
--- a/leveldb/src/main/java/org/iq80/leveldb/impl/VersionEdit.java
+++ b/leveldb/src/main/java/org/iq80/leveldb/impl/VersionEdit.java
@@ -119,8 +119,7 @@ public class VersionEdit {
                         InternalKey smallest,
                         InternalKey largest) {
         File file = new File(this.databaseDir, Filename.tableFileName(fileNumber));
-        Preconditions.checkState(file.isFile(), file.getAbsolutePath());
-        FileMetaData fileMetaData = new FileMetaData(fileNumber, file.length(), smallest, largest);
+        FileMetaData fileMetaData = new FileMetaData(fileNumber, file.isFile() ? file.length() : fileSize, smallest, largest);
         addFile(level, fileMetaData);
     }
 


### PR DESCRIPTION
since the manifest also stores some historical information, it might contain an entry for a table file that no longer exists