### PR TITLE
Fix build on Java 11

### DIFF
--- a/leveldb/src/test/java/org/iq80/leveldb/impl/DbImplTest.java
+++ b/leveldb/src/test/java/org/iq80/leveldb/impl/DbImplTest.java
@@ -788,7 +788,6 @@ public class DbImplTest {
         File databaseFile = new File(databaseDir + "/imafile");
         assertTrue(databaseFile.createNewFile());
         new DbStringWrapper(new Options(), databaseFile);
-        new sun.misc.Cache();
     }
 
     @Test


### PR DESCRIPTION
I had to remove this line to get the build to work in JDK 11 - I think the sun.misc.Cache class is not available any more. Didn't seem like this was doing anything anyway - I'm guessing it got there by accident?